### PR TITLE
Publish to yarn

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,6 @@ jobs:
       - run: npm install
       - run: npm run build:lib
       - run: npm publish
-      - run: yarn
       - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,5 +14,7 @@ jobs:
       - run: npm install
       - run: npm run build:lib
       - run: npm publish
+      - run: yarn
+      - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I can't install this package with `yarn add @oruga-ui/theme-bootstrap`. It produces an error like this:
error An unexpected error occurred: "https://registry.yarnpkg.com/@oruga-ui%2ftheme-bootstrap: Not found".

When I manually searched for this package on yarnpkg.com it returned nothing. So my assumption is that this was never published on the yarn registry (for some reason I though yarn uses npm's registry, but perhaps that is not true).

Anyway, I believe the commit here will do this for you automatically. I have not tested it, so please review before you merge my changes.

https://classic.yarnpkg.com/lang/en/docs/publishing-a-package/


Thank you for working on this great project.