### PR TITLE
fix(table): solve sortable column width problem

### DIFF
--- a/src/assets/scss/components/_table.scss
+++ b/src/assets/scss/components/_table.scss
@@ -129,6 +129,7 @@ $table-card-spacer: $spacer;
                 > span {
                     display: block;
                     position: relative;
+                    width: inherit;
                 }
 
                 &:hover {


### PR DESCRIPTION
- add `width: inherit;` to the inner column span when column ist sortable